### PR TITLE
Pin markdown dependency to major version 2.x

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -4,6 +4,6 @@
     <title>Airlock</title>
     <dependency processor="http://exist-db.org" semver-min="5.2.99"/>
     <dependency package="http://joewiz.org/ns/pkg/airtable" semver-min="1.0.1" semver-max="1.99.99"/>
-    <dependency package="http://exist-db.org/apps/markdown"/>
+    <dependency package="http://exist-db.org/apps/markdown" semver="2"/>
     <dependency package="http://e-editiones.org/roaster"/>
 </package>


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

## Summary

The [eXist-markdown](https://github.com/eXist-db/exist-markdown) library is moving to v3.0.0 ([PR #69](https://github.com/eXist-db/exist-markdown/pull/69)), a major rewrite that replaces its regex-based parser with flexmark-java. The v3 output structure differs from v2.

This PR pins the previously unversioned markdown dependency in `expath-pkg.xml` to `semver="2"`, keeping airlock on v2.x until v3 compatibility is verified.

## Test plan

- [x] Manifest-only change, no functional impact on the v2 dependency